### PR TITLE
Interface for mocking Client data

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,35 @@ Client.UpdateSchedule(schedule *Schedule, bucketKey string, testID string) (*Sch
 
 Client.DeleteSchedule(schedule *Schedule, bucketKey string, testID string) error
 ```
+### Unit Testing
+You can now mock client data:
+
+```
+type MockClient struct {
+}
+
+func (client *MockClient) ListBuckets() ([]*runscope.Bucket, error) {
+ 	bucket1 := new(runscope.Bucket)
+ 	bucket2 := new(runscope.Bucket)
+ 	bucket1.Name = "MyBucket"
+ 	bucket2.Name = "MyNonExistingBucket"
+ 	return []*runscope.Bucket{bucket1, bucket2}, nil
+ }
+ ```
+Then you can use this mockClient in your Unit Test:
+```
+func TestReadBucket(t *testing.T) {
+	t.Run("Successful return bucket", func(t *testing.T) {
+		client := new(resources.MockClient)
+		getBucket := ReadBucket("MyBucket", client)
+
+		if getBucket == nil {
+			t.Error("Should have returned a bucket")
+		}
+	})
+}
+```
+
 ## Developing
 ### Running the tests
 By default the tests requiring access to the runscope api (most of them)

--- a/README.md
+++ b/README.md
@@ -184,8 +184,8 @@ type MockClient struct {
 }
 
 func (client *MockClient) ListBuckets() ([]*runscope.Bucket, error) {
- 	bucket1 := new(runscope.Bucket)
- 	bucket2 := new(runscope.Bucket)
+ 	bucket1 := &runscope.Bucket{}
+ 	bucket2 := &runscope.Bucket{}
  	bucket1.Name = "MyBucket"
  	bucket2.Name = "MyNonExistingBucket"
  	return []*runscope.Bucket{bucket1, bucket2}, nil
@@ -195,7 +195,7 @@ Then you can use this mockClient in your Unit Test:
 ```
 func TestReadBucket(t *testing.T) {
 	t.Run("Successful return bucket", func(t *testing.T) {
-		client := new(resources.MockClient)
+		client := &resources.MockClient{}
 		getBucket := ReadBucket("MyBucket", client)
 
 		if getBucket == nil {

--- a/client.go
+++ b/client.go
@@ -89,7 +89,7 @@ func NewClient(apiURL string, accessToken string) *Client {
 	return &client
 }
 
-// Utilizing ClientAPI Interface
+// NewClientAPI Interface initialization
 func NewClientAPI(apiURL string, accessToken string) ClientAPI {
 	return &Client{
 		APIURL: apiURL,

--- a/client.go
+++ b/client.go
@@ -18,6 +18,37 @@ import (
 // APIURL is the default runscope api uri
 const APIURL = "https://api.runscope.com"
 
+// ClientAPI interface for mocking data in unit tests
+type ClientAPI interface {
+	CreateBucket(bucket *Bucket) (*Bucket, error)
+	CreateSchedule(schedule *Schedule, bucketKey string, testID string) (*Schedule, error)
+	CreateSharedEnvironment(environment *Environment, bucket *Bucket) (*Environment, error)
+	CreateTest(test *Test) (*Test, error)
+	CreateTestEnvironment(environment *Environment, test *Test) (*Environment, error)
+	CreateTestStep(testStep *TestStep, bucketKey string, testID string) (*TestStep, error)
+	DeleteBucket(key string) error
+	DeleteBuckets(predicate func(bucket *Bucket) bool) error
+	DeleteEnvironment(environment *Environment, bucket *Bucket) error
+	DeleteSchedule(schedule *Schedule, bucketKey string, testID string) error
+	DeleteTest(test *Test) error
+	DeleteTestStep(testStep *TestStep, bucketKey string, testID string) error
+	ListBuckets() ([]*Bucket, error)
+	ListIntegrations(teamID string) ([]*Integration, error)
+	ListPeople(teamID string) ([]*People, error)
+	ReadBucket(key string) (*Bucket, error)
+	ReadSchedule(schedule *Schedule, bucketKey string, testID string) (*Schedule, error)
+	ReadSharedEnvironment(environment *Environment, bucket *Bucket) (*Environment, error)
+	ReadTest(test *Test) (*Test, error)
+	ReadTestEnvironment(environment *Environment, test *Test) (*Environment, error)
+	ReadTestStep(testStep *TestStep, bucketKey string, testID string) (*TestStep, error)
+	ReadTests(bucketKey string) ([]*Test, error)
+	UpdateSchedule(schedule *Schedule, bucketKey string, testID string) (*Schedule, error)
+	UpdateSharedEnvironment(environment *Environment, bucket *Bucket) (*Environment, error)
+	UpdateTest(test *Test) (*Test, error)
+	UpdateTestEnvironment(environment *Environment, test *Test) (*Environment, error)
+	UpdateTestStep(testStep *TestStep, bucketKey string, testID string) (*TestStep, error)
+}
+
 // Client provides access to create, read, update and delete runscope resources
 type Client struct {
 	APIURL      string
@@ -49,6 +80,17 @@ type metaResponse struct {
 
 // NewClient creates a new client instance
 func NewClient(apiURL string, accessToken string) *Client {
+	client := Client{
+		APIURL:      apiURL,
+		AccessToken: accessToken,
+		HTTP:        cleanhttp.DefaultClient(),
+	}
+
+	return &client
+}
+
+// Utilizing ClientAPI Interface
+func NewClientAPI(apiURL string, accessToken string) ClientAPI {
 	client := Client{
 		APIURL:      apiURL,
 		AccessToken: accessToken,

--- a/client.go
+++ b/client.go
@@ -91,13 +91,11 @@ func NewClient(apiURL string, accessToken string) *Client {
 
 // Utilizing ClientAPI Interface
 func NewClientAPI(apiURL string, accessToken string) ClientAPI {
-	client := Client{
-		APIURL:      apiURL,
+	return &Client{
+		APIURL: apiURL,
 		AccessToken: accessToken,
-		HTTP:        cleanhttp.DefaultClient(),
+		HTTP: cleanhttp.DefaultClient(),
 	}
-
-	return &client
 }
 
 func (client *Client) createResource(


### PR DESCRIPTION
Relates to: https://github.com/ewilde/go-runscope/issues/7

=== RUN   TestCreateBucket
--- PASS: TestCreateBucket (0.78s)
=== RUN   TestDeleteBuckets
--- PASS: TestDeleteBuckets (2.56s)
=== RUN   TestListBuckets
--- PASS: TestListBuckets (1.95s)
=== RUN   TestReadBucket
--- PASS: TestReadBucket (1.09s)
=== RUN   TestBucketReadFromResponse
--- PASS: TestBucketReadFromResponse (0.00s)
=== RUN   TestDeserializeResult
--- PASS: TestDeserializeResult (0.00s)
=== RUN   TestCreateSharedEnvironment
--- PASS: TestCreateSharedEnvironment (2.21s)
=== RUN   TestCreateTestEnvironment
--- PASS: TestCreateTestEnvironment (3.31s)
=== RUN   TestReadEnvironmentFromResponse
--- PASS: TestReadEnvironmentFromResponse (0.00s)
=== RUN   TestCreateSchedule
--- PASS: TestCreateSchedule (4.30s)
=== RUN   TestReadSchedule
--- PASS: TestReadSchedule (4.30s)
=== RUN   TestUpdateSchedule
--- PASS: TestUpdateSchedule (6.87s)
=== RUN   TestDeleteSchedule
--- PASS: TestDeleteSchedule (4.30s)
=== RUN   TestListIntegration
--- PASS: TestListIntegration (0.40s)
=== RUN   TestCreateTestStep
--- PASS: TestCreateTestStep (3.92s)
=== RUN   TestReadTestStep
--- PASS: TestReadTestStep (3.67s)
=== RUN   TestUpdateTestStep
--- PASS: TestUpdateTestStep (4.91s)
=== RUN   TestDeleteTestStep
--- PASS: TestDeleteTestStep (3.78s)
=== RUN   TestValidationRequestTypeMissingMethod
--- PASS: TestValidationRequestTypeMissingMethod (0.00s)
=== RUN   TestValidationRequestTypeGetIncludesBody
--- PASS: TestValidationRequestTypeGetIncludesBody (0.00s)
=== RUN   TestCreateTest
--- PASS: TestCreateTest (2.19s)
=== RUN   TestReadTest
--- PASS: TestReadTest (2.33s)
=== RUN   TestReadTests
--- PASS: TestReadTests (3.84s)
=== RUN   TestUpdateTest
--- PASS: TestUpdateTest (2.69s)
=== RUN   TestUpdateTestUsingPartiallyFilledOutObject
--- PASS: TestUpdateTestUsingPartiallyFilledOutObject (3.08s)
=== RUN   TestReadFromResponse
--- PASS: TestReadFromResponse (0.00s)
PASS
ok  	github.com/pagnmickie/go-runscope	63.238s
?   	github.com/pagnmickie/go-runscope/examples	[no test files]
