### PR TITLE
Pagination support to list all tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ environment variables.
 ```bash
 RUNSCOPE_ACC=true
 RUNSCOPE_ACCESS_TOKEN={your access token}
-RUNSCOPE_TEAM_UUID={your team uuid}
+RUNSCOPE_TEAM_ID={your team uuid}
 ```
 Access tokens can be created using the [applications](https://www.runscope.com/applications)
 section of your runscope account.
@@ -231,4 +231,3 @@ Your team url can be found by taking the uuid from https://www.runscope.com/team
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)
 5. Create a new Pull Request
-

--- a/bucket.go
+++ b/bucket.go
@@ -146,6 +146,7 @@ func (client *Client) ListAllTests(input *ListTestsInput) ([]*Test, error) {
 		BucketKey: input.BucketKey,
 		Count:     input.Count,
 	}
+	
 	if cfg.Count == 0 {
 		cfg.Count = DefaultPageSize
 	}

--- a/bucket.go
+++ b/bucket.go
@@ -150,6 +150,7 @@ func (client *Client) ListAllTests(input *ListTestsInput) ([]*Test, error) {
 	if cfg.Count == 0 {
 		cfg.Count = DefaultPageSize
 	}
+	
 	for cfg.Offset = 0; ; cfg.Offset += cfg.Count {
 		tests, err := client.ListTests(cfg)
 		if err != nil {

--- a/bucket.go
+++ b/bucket.go
@@ -156,6 +156,7 @@ func (client *Client) ListAllTests(input *ListTestsInput) ([]*Test, error) {
 		if err != nil {
 			return allTests, err
 		}
+		
 		allTests = append(allTests, tests...)
 		if len(tests) < cfg.Count {
 			return allTests, nil

--- a/bucket_test.go
+++ b/bucket_test.go
@@ -76,6 +76,37 @@ func TestListBuckets(t *testing.T) {
 	}
 }
 
+func TestListAllTests(t *testing.T) {
+	testPreCheck(t)
+	client := clientConfigure()
+	bucket, err := client.CreateBucket(&Bucket{Name: "test-list-all-tests", Team: &Team{ID: teamID}})
+	defer client.DeleteBucket(bucket.Key)
+	if err != nil {
+		t.Error(err)
+	}
+
+	numTests := 5
+	for i := 0; i < numTests; i++ {
+		_, err := client.CreateTest(&Test{
+			Name:        fmt.Sprintf("some_test_%d", i),
+			Description: "some desc",
+			Bucket:      bucket,
+		})
+		if err != nil {
+			t.Error(err)
+		}
+	}
+
+	tests, err := client.ListAllTests(&ListTestsInput{
+		BucketKey: bucket.Key,
+		Count:     1,
+	})
+
+	if len(tests) != numTests {
+		t.Errorf("Length of tests expected %v, actual:%v", numTests, len(tests))
+	}
+}
+
 func TestReadBucket(t *testing.T) {
 	testPreCheck(t)
 	client := clientConfigure()

--- a/client_test.go
+++ b/client_test.go
@@ -75,14 +75,9 @@ func deletePredicate(bucket *Bucket) bool {
 }
 
 func TestMain(m *testing.M) {
-
 	client := clientConfigure()
 	client.DeleteBuckets(deletePredicate)
-
 	code := m.Run()
-
 	client.DeleteBuckets(deletePredicate)
-
 	os.Exit(code)
-
 }

--- a/test_test.go
+++ b/test_test.go
@@ -428,7 +428,7 @@ func TestListsTests(t *testing.T) {
 		t.Error(err)
 	}
 
-	tests, err := client.ListTests(&ListTestsInput{BucketName: bucket.Key})
+	tests, err := client.ListTests(&ListTestsInput{BucketKey: bucket.Key})
 	if err != nil {
 		t.Error(err)
 	}
@@ -464,7 +464,7 @@ func TestListsTestsMoreThan10(t *testing.T) {
 		t.Error(err)
 	}
 
-	tests, err := client.ListTests(&ListTestsInput{BucketName: bucket.Key, Count: 20})
+	tests, err := client.ListTests(&ListTestsInput{BucketKey: bucket.Key, Count: 20})
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
* Renames `BucketName` to `BucketKey` in `ListTestsInput` to be consistent with Runscope API. Really, even many of the integration tests were doing `BucketName: bucket.Key`, which also warrents the correction.

* Add `Offset` field to `ListTestsInput` so pagination is possible. This is a field offcially supported by the Runscope API https://www.runscope.com/docs/api/tests#list.

* Correct the docstring on `ListTests()` since it does NOT list all tests, and implement another `ListAllTests()` function using pagination with test coverage.

* All tests passed locally.