### PR TITLE
Change avg_response_time_ms to float

### DIFF
--- a/test.go
+++ b/test.go
@@ -92,7 +92,7 @@ type TestMetric struct {
 type ResponseTime struct {
 	SuccessRatio          float64 `json:"success_ratio,omitempty"`
 	Timestamp             int64   `json:"timestamp,omitempty"`
-	AverageResponseTimeMs int     `json:"avg_response_time_ms,omitempty"`
+	AverageResponseTimeMs float64 `json:"avg_response_time_ms,omitempty"`
 }
 
 type TimePeriodMetic struct {


### PR DESCRIPTION
Runscope API is returning floats for this type, sample response:

```
{
  "response_times": [
    {
      "timestamp": 1602028800,
      "avg_response_time_ms": 332.3697916666667,
      "success_ratio": 1.0
    }
  ]
}
```