### PR TITLE
Send correct content-type when creating bucket

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -1,13 +1,12 @@
 /*
-Package runscope implements a client library for the runscope api (https://www.runscope.com/docs/api)
-
+Package runscope implements a client library for the runscope api (https://api.blazemeter.com/api-monitoring/)
 */
 package runscope
 
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/url"
 )
 
@@ -16,7 +15,8 @@ const (
 	DefaultPageSize = 10
 )
 
-// Bucket resources are a simple way to organize your requests and tests. See https://www.runscope.com/docs/api/buckets and https://www.runscope.com/docs/buckets
+// Bucket resources are a simple way to organize your requests and tests.
+// See https://api.blazemeter.com/api-monitoring/#buckets and https://www.runscope.com/docs/buckets
 type Bucket struct {
 	Name           string `json:"name,omitempty"`
 	Key            string `json:"key,omitempty"`
@@ -30,16 +30,16 @@ type Bucket struct {
 	Team           *Team  `json:"team,omitempty"`
 }
 
-// CreateBucket creates a new bucket resource. See https://www.runscope.com/docs/api/buckets#bucket-create
+// CreateBucket creates a new bucket resource. See https://api.blazemeter.com/api-monitoring/#creating-a-bucket
 func (client *Client) CreateBucket(bucket *Bucket) (*Bucket, error) {
 	DebugF(1, "creating bucket %s", bucket.Name)
-	data := url.Values{}
-	data.Add("name", bucket.Name)
-	data.Add("team_uuid", bucket.Team.ID)
 
-	DebugF(2, "	request: POST %s %#v", "/buckets", data)
+	endpoint := fmt.Sprintf("/buckets?name=%s&team_uuid=%s",
+		url.QueryEscape(bucket.Name), url.QueryEscape(bucket.Team.ID))
 
-	req, err := client.newFormURLEncodedRequest("POST", "/buckets", data)
+	DebugF(2, "	request: POST %s", endpoint)
+
+	req, err := client.newRequest("POST", endpoint, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -51,7 +51,7 @@ func (client *Client) CreateBucket(bucket *Bucket) (*Bucket, error) {
 	}
 	defer resp.Body.Close()
 
-	bodyBytes, _ := ioutil.ReadAll(resp.Body)
+	bodyBytes, _ := io.ReadAll(resp.Body)
 	bodyString := string(bodyBytes)
 	DebugF(2, "	response: %d %s", resp.StatusCode, bodyString)
 

--- a/client.go
+++ b/client.go
@@ -5,11 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"net/url"
-
-	"io/ioutil"
-	"strings"
 	"sync"
 
 	"github.com/hashicorp/go-cleanhttp"
@@ -213,7 +211,7 @@ func (client *Client) updateResource(resource interface{}, resourceType string, 
 	}
 	defer resp.Body.Close()
 
-	bodyBytes, _ := ioutil.ReadAll(resp.Body)
+	bodyBytes, _ := io.ReadAll(resp.Body)
 	bodyString := string(bodyBytes)
 	DebugF(2, "	response: %d %s", resp.StatusCode, bodyString)
 
@@ -251,7 +249,7 @@ func (client *Client) deleteResource(resourceType string, resourceName string, e
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 300 {
-		bodyBytes, _ := ioutil.ReadAll(resp.Body)
+		bodyBytes, _ := io.ReadAll(resp.Body)
 		bodyString := string(bodyBytes)
 		DebugF(2, "%s", bodyString)
 
@@ -266,25 +264,6 @@ func (client *Client) deleteResource(resourceType string, resourceName string, e
 	}
 
 	return nil
-}
-
-func (client *Client) newFormURLEncodedRequest(method string, endpoint string, data url.Values) (*http.Request, error) {
-	urlStr := client.APIURL + endpoint
-	url, err := url.Parse(urlStr)
-	if err != nil {
-		return nil, fmt.Errorf("Error during parsing request URL: %s", err)
-	}
-
-	req, err := http.NewRequest(method, url.String(), strings.NewReader(data.Encode()))
-	if err != nil {
-		return nil, fmt.Errorf("Error during creation of request: %s", err)
-	}
-
-	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", client.AccessToken))
-	req.Header.Add("Accept", "application/json")
-	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-
-	return req, nil
 }
 
 func (client *Client) newRequest(method string, endpoint string, body []byte) (*http.Request, error) {


### PR DESCRIPTION
Bucket creation request must have the `application/json` content-type according to [the runscope documentation](https://api.blazemeter.com/api-monitoring/#creating-a-bucket). This content type is being enforced now and providing `application/x-www-form-urlencoded` causes a `415 Unsupported Media Type` response.

Before the change the tests were failing with following error:
```
=== RUN   TestCreateBucket
[DEBUG] creating bucket test
[DEBUG]	 	request: POST /buckets url.Values{"name":[]string{"test"}, "team_uuid":[]string{"0b648b14-4e1c-49e2-aad6-013cdf0d8f5f"}}
[DEBUG]	 &http.Request{Method:"POST", URL:(*url.URL)(0xc0004d4750), Proto:"HTTP/1.1", ProtoMajor:1, ProtoMinor:1, Header:http.Header{"Accept":[]string{"application/json"}, "Authorization":[]string{"Bearer e84c44cb-2533-4a32-814c-6657e9ce3f5f"}, "Content-Type":[]string{"application/x-www-form-urlencoded"}}, Body:io.nopCloserWriterTo{Reader:(*strings.Reader)(0xc0002bcbc0)}, GetBody:(func() (io.ReadCloser, error))(0x66ff60), ContentLength:56, TransferEncoding:[]string(nil), Close:false, Host:"api.runscope.com", Form:url.Values(nil), PostForm:url.Values(nil), MultipartForm:(*multipart.Form)(nil), Trailer:http.Header(nil), RemoteAddr:"", RequestURI:"", TLS:(*tls.ConnectionState)(nil), Cancel:(<-chan struct {})(nil), Response:(*http.Response)(nil), ctx:(*context.emptyCtx)(0xc00001a140)}
[DEBUG]	 	response: 415 {"data": {}, "meta": {"status": "error"}, "error": {"status": 415, "message": "Unsupported Media Type"}}

    bucket_test.go:15: Error creating bucket: test
--- FAIL: TestCreateBucket (0.24s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x6a434d]

goroutine 107 [running]:
testing.tRunner.func1.2({0x6e8d60, 0x96f5b0})
	/usr/local/go/src/testing/testing.go:1396 +0x24e
testing.tRunner.func1()
	/usr/local/go/src/testing/testing.go:1399 +0x39f
panic({0x6e8d60, 0x96f5b0})
	/usr/local/go/src/runtime/panic.go:884 +0x212
github.com/ewilde/go-runscope.TestCreateBucket(0xc000358d00)
	/home/iyigun/go/src/github.com/ewilde/go-runscope/bucket_test.go:18 +0x10d
testing.tRunner(0xc000358d00, 0x766de8)
	/usr/local/go/src/testing/testing.go:1446 +0x10b
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1493 +0x35f
FAIL	github.com/ewilde/go-runscope	23.702s
?   	github.com/ewilde/go-runscope/examples	[no test files]
```